### PR TITLE
Fix #894 - remove unneeded(?) aldeed:http library which was causing w…

### DIFF
--- a/packages/upload-http/package.js
+++ b/packages/upload-http/package.js
@@ -13,8 +13,7 @@ Package.onUse(function(api) {
     'cfs:file@0.1.16',
     'cfs:access-point@0.1.49',
     'cfs:power-queue@0.9.11',
-    'cfs:reactive-list@0.0.9',
-    'aldeed:http'
+    'cfs:reactive-list@0.0.9'
   ]);
 
   api.addFiles([


### PR DESCRIPTION
…arnings

@nooitaf I poked around a bit more, and the behavior is actually a bit
more subtle.

The upload-http package is pulling in https://github.com/aldeed/meteor-http-extras.
Do you know why this dependency exists?  I see that package.js is referencing aldeed:http but upload-http
doesn't seem to use any of the features this patch to HTTP adds.

I'll attach a PR in moments which removes this dependency - everything seems to work nicely without it.

It turns out the bug is in aldeed:http, and when upload-http pulls in this
patch _every_ call to HTTP.call (including calls from other packages)
generates this warning message (because most callers are not setting responseType).

If ya'll do need aldeed:http let me know, and instead I'll send them
a fix for the bug in their lib.